### PR TITLE
FEATURE: custom anonymization callback

### DIFF
--- a/Classes/Domain/Anonymizable.php
+++ b/Classes/Domain/Anonymizable.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace Aerticket\DataAnonymizer\Domain;
+
+
+use Neos\Flow\Persistence\QueryInterface;
+
+interface Anonymizable
+{
+    /**
+     * Executes custom anonymization of an object
+     *
+     * @return void
+     */
+    public function anonymize(): void;
+
+    /**
+     * Returns whether the given entity already is anonymized.
+     *
+     * This method is not used in automated anonymization but can be used e.g. in your anonymize
+     * implementation or other user-land code handling this entity.
+     *
+     * @return bool
+     */
+    public function isAnonymized(): bool;
+
+    /**
+     * Create the constraints to use in a query to determine whether the entity is anonymized, e.g.
+     * by checking for a certain property or by testing if a field _contains_ a value.
+     *
+     * The result should be an array of constraints to be fed into a logicalAnd, e.g.
+     * ```
+     * [
+     *   $query->equals('name', 'Anon'),
+     *   $query->or([
+     *     $query->like('data', '%anon@example.com%'),
+     *     $query->like('data', '%anon2@example.com%'),
+     *   ]),
+     * ]
+     * ```
+     *
+     * @param QueryInterface $query
+     * @return array
+     */
+    public static function createAnonymizationStateConstraints(QueryInterface $query): array;
+}

--- a/README.md
+++ b/README.md
@@ -100,6 +100,35 @@ of the property:
   }
 ``` 
 
+## Custom Anonymization Action
+By implementing the `Aerticket\DataAnonymizer\Domain\Anonymizable` interface, you can implement a `anonymize` callback to be called by the `AnonymizationService`.
+This might be useful if you need to anonymize *part* of the data in your entity, e.g. certain keys in an array.  
+Additionally you need to implement the `createAnonymizationStateConstraints` function, returning query constraints to statically determine whether your entity needs anonymization.
+Depending on your entity this may be as simple as checking an `isAnonymized` property, but you may check for multiple fields:
+```php
+/**
+ * @param QueryInterface $query
+ * @return array
+ */
+public static function createAnonymizationStateConstraints(QueryInterface $query): array
+{
+    return [
+        $query->equals('name', 'Anon'),
+        $query->or([
+          $query->like('data', '%"anon@example.com"%'),
+          $query->like('data', '%"Anon Str. 12"%'),
+        ]),
+    ];
+}
+
+public function anonymize(): void {
+    $this->setName('Anon');
+    $data = $this->getData();
+    $data['street'] = 'Anon Str. 12';
+    $this->setData($data);
+}
+```
+
 ## Limitations
 
 The following limitations apply at the moment:


### PR DESCRIPTION
Provides an interface with a callback for custom anonymization and a static method to create query constraints to check for entities to be anonymized in your database.

See interface and readme for usage examples.

Unfortunately this implementation needs to check multiple times if the entity (or its class) implements the new interface.

Additionally it could be viable to make the `anonymize` method to return a bool determining whether the default anonymization based on property annotations should still be performed to leverage some basic anonymization actions.